### PR TITLE
(Bug) SCWSFP-50: Fix the Date Formatting in Contracts Page

### DIFF
--- a/src/Pages/Contracts.js
+++ b/src/Pages/Contracts.js
@@ -37,10 +37,7 @@ export default function ContractsPage() {
                         <thead>
                             <tr>
                                 <th>Final Price</th>
-                                <th>Down Payment</th>
                                 <th>Date Commissioned</th>
-                                <th>End Date</th>
-                                <th>Was Signed?</th>
                                 <th>Is Finished?</th>
                             </tr>
                         </thead>
@@ -48,12 +45,14 @@ export default function ContractsPage() {
                             {contracts.map((item) => (
                                 <tr key={item.ContractId} id={"Contract-" + item.ContractId}>
                                     <td>${item.FinalCost}</td>
-                                    <td>${item.DownPayment}</td>
-                                    <td>{item.DateCommissioned}</td>
-                                    <td>{item.EndDate}</td>
-                                    <td>{item.HasSignature ? "Yes" : "No"}</td>
+                                    <td>{(new Date(item.DateCommissioned).toLocaleDateString())}</td>
                                     <td>{item.IsFinished ? "Yes" : "No"}</td>
-                                    <td><button type='button' name={item.ContractId + "DetailsBtn"} className='btn btn-primary' onClick={() => redirect({id: item.ContractId})}>Check Details</button></td>
+                                    <td><button type='button'
+                                                name={item.ContractId + "DetailsBtn"}
+                                                className='btn btn-primary'
+                                                onClick={() => redirect({id: item.ContractId})}>
+                                                    {item.IsFinished ? "View Details" : "Update Contract"}
+                                                </button></td>
                                 </tr>
                             ))}
                         </tbody>


### PR DESCRIPTION
### Context
- Seeking to remove the time in the contracts page for dates where the time is displayed wo/spaces

### Changes
- Fixed the date formatting
- Reorganized the table to display a summary of the contracts
- Added context sensitivity to the text of the buttons based on whether a contract is finished

Jira Link: https://champlainsaintlambert.atlassian.net/browse/SCWSFP-50